### PR TITLE
Added information surrounding ssl certkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ It is preferable to create specific user for data scraping from Citrix ADC with 
 
 ```
 # Create a new Command Policy which is only allowed to run the stat command
-add system cmdPolicy stats-policy ALLOW (^stat.*|show ns license|show serviceGroup)
+add system cmdPolicy stats-policy ALLOW (^stat.*|show ns license|show serviceGroup|show ssl certKey)
 
 # Create a new user  
 # Change the 'password' in accordance with your password policy

--- a/metrics.json
+++ b/metrics.json
@@ -34,6 +34,16 @@
         ]
     },
 
+    "sslcertkey": {
+        "counters": [
+            ["daystoexpiration", "ssl_cert_days_to_expire"]
+        ],
+        "guages": [],
+        "labels": [
+            ["certkey", "cert_key"]
+        ]
+    },
+
     "protocolhttp": {
         "counters": [
             ["httptotrequests", "http_tot_requests"],
@@ -312,7 +322,7 @@
 
     "lbvserver_binding": {
         "counters": [
-            ["percentup","lb_members_up_total"]
+            ["percentup", "lb_members_up_total"]
         ],
 
         "labels": [
@@ -376,7 +386,7 @@
         ]
     },
 
-   "ns": {
+    "ns": {
         "gauges": [
             ["rxmbitsrate", "througput_rx_mbits_rate"]
         ]


### PR DESCRIPTION
Added informaiton in README.md about permissions required for pulling metrics about the ssl certkeys.  Also, added information in metrics.json on how to actually pull the ssl cert keys with labels to identify them.