### PR TITLE
Adding /var and /flash usage metrics

### DIFF
--- a/metrics.json
+++ b/metrics.json
@@ -10,6 +10,12 @@
             ["mgmtcpuusagepcnt", "citrixadc_management_cpu_usage_percent"],
             ["pktcpuusagepcnt", "citrixadc_packet_cpu_usage_percent"],
             ["rescpuusagepcnt", "citrixadc_res_cpu_usage_percent"]
+            ["disk1avail", "citrixadc_var_partition_free_mb"],
+            ["disk1used", "citrixadc_var_partition_used_mb"],
+            ["disk1perusage", "citrixadc_var_partition_used_percent"],
+            ["disk0avail", "citrixadc_flash_partition_free_mb"],
+            ["disk0used", "citrixadc_flash_partition_used_mb"],
+            ["disk0perusage", "citrixadc_flash_partition_used_percent"]
         ]
     },
 


### PR DESCRIPTION
Observing /flash and /var usage on a Netscaler is important and should be included in the default metrics.json. Added metrics for disk0 (flash) and (disk1) var in MB and percent.