### PR TITLE
fix test/login/logout eternal loops and small refactor around session

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -103,20 +103,19 @@ class TimeoutHTTPAdapter(HTTPAdapter):
         if "max_retries" in kwargs:
             self.max_retries = kwargs["max_retries"]
             del kwargs["max_retries"]
-        super(HTTPAdapter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def get(self, request, **kwargs):
         timeout = kwargs.get("timeout")
         if timeout is None:
             kwargs["timeout"] = self.timeout
-        return super(HTTPAdapter, self).get(request, **kwargs)
+        return super().get(request, **kwargs)
     
     def post(self, request, **kwargs):
         timeout = kwargs.get("timeout")
         if timeout is None:
             kwargs["timeout"] = self.timeout
-        return super(HTTPAdapter, self).post(request, **kwargs)
-
+        return super().post(request, **kwargs)
 
 def newSession(retries=3, backoff_factor=1, timeout=None, session=None):
     session = session or requests.Session()


### PR DESCRIPTION
although contribution outside citrix are not being accepted it may be interesting to check the changes I did.

i removed the initial checks because i don't see the point to check if you are able to connect to the adc in an eternal loop, also removed the loop from login and logout as it can kill the management CPU by the 1 second rate defined. this code tries to authenticate 3 times and exit if not possible. i have created a systemd service file that tries to restart the exporter every 5 minutes then - these kind of logic should be outside the exporter.

for issues when getting stats it would be awesome to reply a 500 or reply that the exporter is down with the up metric - i'm still not sure how to handle parcial failures though (e.g. can get some stats, but not all).

as you only use get and post i override these methods to take timeout from the session declaration so that we can have a clear retry, backoff and timeout policy in place.

as I am no expert python dev there can be idiomatic issues, for sure.
bonus: works with python3